### PR TITLE
Feature/pb 612 nye topics

### DIFF
--- a/src/main/avro/feilrespons.avsc
+++ b/src/main/avro/feilrespons.avsc
@@ -1,0 +1,16 @@
+{
+    "type": "record",
+    "namespace": "no.nav.brukernotifikasjon.schemas.internal",
+    "name": "Feilrespons",
+    "fields": [
+        {
+            "name": "tidspunkt",
+            "type": "long",
+            "logicalType": "timestamp-millis"
+        },
+        {
+            "name": "feilmelding",
+            "type": "string"
+        }
+    ]
+}

--- a/src/main/avro/nokkelFeilrespons.avsc
+++ b/src/main/avro/nokkelFeilrespons.avsc
@@ -1,0 +1,19 @@
+{
+    "type": "record",
+    "namespace": "no.nav.brukernotifikasjon.schemas.internal",
+    "name": "NokkelFeilrespons",
+    "fields": [
+        {
+            "name": "systembruker",
+            "type": "string"
+        },
+        {
+            "name": "eventId",
+            "type": "string"
+        },
+        {
+            "name": "brukernotifikasjonsType",
+            "type": "string"
+        }
+    ]
+}

--- a/src/main/avro/nokkelFeilrespons.avsc
+++ b/src/main/avro/nokkelFeilrespons.avsc
@@ -12,7 +12,7 @@
             "type": "string"
         },
         {
-            "name": "brukernotifikasjonsType",
+            "name": "brukernotifikasjonstype",
             "type": "string"
         }
     ]


### PR DESCRIPTION
La til feilrespons-schemas.

Feilrespons nøkkelen vil ikke inneholde fnr. Dette er fordi eventId skal være unikt innen hver produsent og brukernotifikasjonstype. Dette vil gjøre at daten som ligger på feilrespons-topic-en ikke er så sensitiv. 
