### PR TITLE
Matcher endringer i brukernotifikasjon-schemas

### DIFF
--- a/src/main/avro/beskjedIntern.avsc
+++ b/src/main/avro/beskjedIntern.avsc
@@ -4,10 +4,6 @@
     "name": "BeskjedIntern",
     "fields": [
         {
-            "name": "ulid",
-            "type": "string"
-        },
-        {
             "name": "tidspunkt",
             "type": "long",
             "logicalType": "timestamp-millis"
@@ -17,10 +13,6 @@
             "type": ["null", "long"],
             "logicalType": "timestamp-millis",
             "default": null
-        },
-        {
-            "name": "grupperingsId",
-            "type": "string"
         },
         {
             "name": "tekst",

--- a/src/main/avro/doneIntern.avsc
+++ b/src/main/avro/doneIntern.avsc
@@ -4,17 +4,9 @@
     "name": "DoneIntern",
     "fields": [
         {
-            "name": "ulid",
-            "type": "string"
-        },
-        {
             "name": "tidspunkt",
             "type": "long",
             "logicalType": "timestamp-millis"
-        },
-        {
-            "name": "grupperingsId",
-            "type": "string"
         }
     ]
 }

--- a/src/main/avro/innboksIntern.avsc
+++ b/src/main/avro/innboksIntern.avsc
@@ -4,17 +4,9 @@
     "name": "InnboksIntern",
     "fields": [
         {
-            "name": "ulid",
-            "type": "string"
-        },
-        {
             "name": "tidspunkt",
             "type": "long",
             "logicalType": "timestamp-millis"
-        },
-        {
-            "name": "grupperingsId",
-            "type": "string"
         },
         {
             "name": "tekst",

--- a/src/main/avro/nokkelFeilrespons.avsc
+++ b/src/main/avro/nokkelFeilrespons.avsc
@@ -4,15 +4,23 @@
     "name": "NokkelFeilrespons",
     "fields": [
         {
-            "name": "systembruker",
-            "type": "string"
-        },
-        {
             "name": "eventId",
             "type": "string"
         },
         {
             "name": "brukernotifikasjonstype",
+            "type": "string"
+        },
+        {
+            "name": "namespace",
+            "type": "string"
+        },
+        {
+            "name": "appnavn",
+            "type": "string"
+        },
+        {
+            "name": "systembruker",
             "type": "string"
         }
     ]

--- a/src/main/avro/nokkelIntern.avsc
+++ b/src/main/avro/nokkelIntern.avsc
@@ -4,7 +4,7 @@
     "name": "NokkelIntern",
     "fields": [
         {
-            "name": "systembruker",
+            "name": "ulid",
             "type": "string"
         },
         {
@@ -12,7 +12,23 @@
             "type": "string"
         },
         {
+            "name": "grupperingsId",
+            "type": "string"
+        },
+        {
             "name": "fodselsnummer",
+            "type": "string"
+        },
+        {
+            "name": "namespace",
+            "type": "string"
+        },
+        {
+            "name": "appnavn",
+            "type": "string"
+        },
+        {
+            "name": "systembruker",
             "type": "string"
         }
     ]

--- a/src/main/avro/oppgaveIntern.avsc
+++ b/src/main/avro/oppgaveIntern.avsc
@@ -4,17 +4,9 @@
     "name": "OppgaveIntern",
     "fields": [
         {
-            "name": "ulid",
-            "type": "string"
-        },
-        {
             "name": "tidspunkt",
             "type": "long",
             "logicalType": "timestamp-millis"
-        },
-        {
-            "name": "grupperingsId",
-            "type": "string"
         },
         {
             "name": "tekst",

--- a/src/main/avro/statusoppdateringIntern.avsc
+++ b/src/main/avro/statusoppdateringIntern.avsc
@@ -4,17 +4,9 @@
     "name": "StatusoppdateringIntern",
     "fields": [
         {
-            "name": "ulid",
-            "type": "string"
-        },
-        {
             "name": "tidspunkt",
             "type": "long",
             "logicalType": "timestamp-millis"
-        },
-        {
-            "name": "grupperingsId",
-            "type": "string"
         },
         {
             "name": "link",

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/internal/BeskjedInternAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/internal/BeskjedInternAvroTest.java
@@ -41,9 +41,7 @@ public class BeskjedInternAvroTest {
 
     private BeskjedIntern getBeskjedWithDefaultValues() {
         return BeskjedIntern.newBuilder()
-                .setUlid("1x2x3x4x5")
                 .setTidspunkt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                .setGrupperingsId("3456789123456")
                 .setTekst("Dette er informasjon du må lese")
                 .setLink("https://gyldig.url")
                 .build();

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/internal/OppgaveInternAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/internal/OppgaveInternAvroTest.java
@@ -34,9 +34,7 @@ public class OppgaveInternAvroTest {
 
     private OppgaveIntern getOppgaveWithDefaultValues() {
         return OppgaveIntern.newBuilder()
-                .setUlid("1x2x3x4x5")
                 .setTidspunkt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                .setGrupperingsId("3456789123456")
                 .setTekst("Du må sende nytt meldekort")
                 .setLink("https://gyldig.url")
                 .build();

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/internal/StatusoppdateringInternAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/internal/StatusoppdateringInternAvroTest.java
@@ -28,9 +28,7 @@ public class StatusoppdateringInternAvroTest {
 
     private StatusoppdateringIntern getStatusoppdateringWithDefaultValues() {
         return StatusoppdateringIntern.newBuilder()
-                .setUlid("1x2x3x4x5")
                 .setTidspunkt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                .setGrupperingsId("3456789123456")
                 .setLink("https://gyldig.url")
                 .setStatusGlobal(StatusGlobal.UNDER_BEHANDLING.toString())
                 .setSakstema("FP")


### PR DESCRIPTION
Matcher endringer i brukernotifikasjon-schemas ved å flytte grupperingsid til nokkel, og legger til namespace og appnavn ved siden av systembruker. Ulid er også flyttet til nokkel.