### PR TITLE
Legg til nytt felt 'behandlet' som indikerer når bnb først mottok og behandlet brukernotifikasjonen.

### DIFF
--- a/src/main/avro/beskjedIntern.avsc
+++ b/src/main/avro/beskjedIntern.avsc
@@ -9,6 +9,12 @@
             "logicalType": "timestamp-millis"
         },
         {
+            "name": "behandlet",
+            "type": ["null", "long"],
+            "logicalType": "timestamp-millis",
+            "default": null
+        },
+        {
             "name": "synligFremTil",
             "type": ["null", "long"],
             "logicalType": "timestamp-millis",

--- a/src/main/avro/doneIntern.avsc
+++ b/src/main/avro/doneIntern.avsc
@@ -7,6 +7,12 @@
             "name": "tidspunkt",
             "type": "long",
             "logicalType": "timestamp-millis"
+        },
+        {
+            "name": "behandlet",
+            "type": ["null", "long"],
+            "logicalType": "timestamp-millis",
+            "default": null
         }
     ]
 }

--- a/src/main/avro/innboksIntern.avsc
+++ b/src/main/avro/innboksIntern.avsc
@@ -9,6 +9,12 @@
             "logicalType": "timestamp-millis"
         },
         {
+            "name": "behandlet",
+            "type": ["null", "long"],
+            "logicalType": "timestamp-millis",
+            "default": null
+        },
+        {
             "name": "tekst",
             "type": "string"
         },

--- a/src/main/avro/oppgaveIntern.avsc
+++ b/src/main/avro/oppgaveIntern.avsc
@@ -15,6 +15,12 @@
             "default": null
         },
         {
+            "name": "behandlet",
+            "type": ["null", "long"],
+            "logicalType": "timestamp-millis",
+            "default": null
+        },
+        {
             "name": "tekst",
             "type": "string"
         },

--- a/src/main/avro/statusoppdateringIntern.avsc
+++ b/src/main/avro/statusoppdateringIntern.avsc
@@ -9,6 +9,12 @@
             "logicalType": "timestamp-millis"
         },
         {
+            "name": "behandlet",
+            "type": ["null", "long"],
+            "logicalType": "timestamp-millis",
+            "default": null
+        },
+        {
             "name": "link",
             "type": "string"
         },


### PR DESCRIPTION
Feltet er default null for bakoverkompatibilitet, men skal alltid settes av bnb for nye eventer. For eldre eventer bør aggregator bruke "tidspunkt" som fallback.

Kom gjerne med bedre navn enn "behandlet"